### PR TITLE
Add filter to modify $start_date for user

### DIFF
--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -119,6 +119,8 @@ function pmprosd_pmpro_profile_start_date($start_date, $order)
 		}
 	}
 		
+	$start_date = apply_filters( 'pmprosd_modify_start_date', $start_date );
+	
 	return $start_date;
 }
 add_filter("pmpro_profile_start_date", "pmprosd_pmpro_profile_start_date", 10, 2);

--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -119,7 +119,7 @@ function pmprosd_pmpro_profile_start_date($start_date, $order)
 		}
 	}
 		
-	$start_date = apply_filters( 'pmprosd_modify_start_date', $start_date );
+	apply_filters( 'pmprosd_modify_start_date', $start_date, $order, $subscription_delay );
 	
 	return $start_date;
 }

--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -81,7 +81,9 @@ add_action("pmpro_save_discount_code_level", "pmprosd_pmpro_save_discount_code_l
 
 //update subscription start date based on the discount code used or levels subscription start date
 function pmprosd_pmpro_profile_start_date($start_date, $order)
-{		
+{	
+	$subscription_delay = null;
+	
 	//if a discount code is used, we default to the setting there
 	if(!empty($order->discount_code))
 	{


### PR DESCRIPTION
Add a filter to let the admin manipulate the start date for the delayed start. This doesn't make sense if the user sets a static $start_date, but can make sense if they use any of the relative $start_date options ('M' or 'Y' for instance.)
