### PR TITLE
BUG: Didn't return a valid startdate from pmpro_profile_start_date

### DIFF
--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Subscription Delays Add On
 Plugin URI: https://www.paidmembershipspro.com/add-ons/subscription-delays/
 Description: Adds a field to delay the start of a subscription for membership levels and discount codes for variable-length trials.
-Version: .4.5
+Version: .4.6
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
 */
@@ -96,9 +96,13 @@ function pmprosd_pmpro_profile_start_date( $start_date, $order ) {
 		$subscription_delay = get_option( 'pmpro_subscription_delay_' . $order->membership_id, '' );
 	}
 
-	if ( ! is_numeric( $subscription_delay ) ) {
+	if ( empty( $subscription_delay ) ) {
+	    return $start_date;
+    }
+    
+	if ( !empty( $subscription_delay ) && ! is_numeric( $subscription_delay ) ) {
 		$start_date = pmprosd_convert_date( $subscription_delay );
-	} else {
+	} else if ( !empty( $subscription_delay ) ) {
 		$start_date = date( 'Y-m-d', strtotime( '+ ' . intval( $subscription_delay ) . ' Days', current_time( 'timestamp' ) ) ) . 'T0:0:0';
 	}
 
@@ -205,9 +209,13 @@ function pmprosd_convert_date( $date ) {
 
 		$new_date = str_replace( $searches, $replacements, $date );
 	}
-
-	$new_date .= 'T0:0:0';
-
+	
+    if ( empty( $new_date ) ) {
+	    $new_date = $date;
+    } else {
+	    $new_date .= 'T0:0:0';
+    }
+    
 	return $new_date;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, memberships, ecommerce
 Requires at least: 3.5
 Tested up to: 4.9.5
-Stable tag: .4.5
+Stable tag: .4.6
 
 Adds a "delay" field to PMPro membership levels and discount codes, allowing you to set a variable-length period between your initial payment (if required) and recurring subscription payment.
 
@@ -24,6 +24,9 @@ Set "delay" to be:
 1. That's it. No settings.
 
 == Changelog ==
+= .4.6 =
+* BUG: Didn't return a valid startdate from pmpro_profile_start_date filter handler
+
 = .4.5 =
 * BUG: Didn't handle the documented M/Y variables (M1 & Y1)
 


### PR DESCRIPTION
The latest update caused an empty value to be returned from the pmpro_profile_start_date filter. This resulted in the 'trial' calculation for subscription plans being set to 0 days of trial which led to users getting charged for both the initial charge _and_ the first subscription payment on the same day (on checkout)