### PR TITLE
BUG FIX: Stripe sets wrong trial period

### DIFF
--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -105,6 +105,13 @@ function pmprosd_pmpro_profile_start_date( $start_date, $order ) {
 	} else {
 		$start_date = date( 'Y-m-d', strtotime( '+ ' . intval( $subscription_delay ) . ' Days', current_time( 'timestamp' ) ) ) . 'T0:0:0';
 	}
+	
+	$today = date( 'Y-m-d\T0:0:0', current_time( 'timestamp' ) );
+	
+	// Stripe does strange things if the profile start is before the current date!
+	if ( $start_date < $today ) {
+		$start_date = $today;
+	}
 
 	$start_date = apply_filters( 'pmprosd_modify_start_date', $start_date, $order, $subscription_delay );
 	return $start_date;


### PR DESCRIPTION
Stripe will configure the wrong trial period for the subscription to start when the profile `startdate` is prior to the current date. 

This can happen if the user has the Subscriptions Delay add-on active and it's configured to start at the beginning of the year, but the member signs up after that date. (I.e. the Subscription Delay value is `2019-01-01` but the day of the subscription checkout is some date _after_ then).

Resetting the `startdate` for the profile won't meet the spirit of the entered subscription delay date in this example.

If the delay value is `2019-01-01` and today is `2019-03-01`, the expected trial end is likely to be `2020-01-01`. 

With this update, it will be `2020-03-01` instead - The fix for this may be to add a filter to the trial period calculation & use that to somehow calculate the appropriate delay to use). 

IMHO the current fix that's better than the subscription trial happening sometime later in 2019 (i.e. in 90ish days, which I've seen on customer sites, leading to an annual member getting billed twice in the membership year).