### PR TITLE
Subscription Delays Reminder Email Implemented

### DIFF
--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -486,7 +486,7 @@ function pmprosd_subscription_delay_reminder(){
 		}
 
 		$send_email = apply_filters("pmprosd_send_reminder_email", true, $e->user_id, $member_levels );
-var_dump($user_reminded);
+
 		/**
 		 * We need to check if: 
 		 * 1. Are we allowed to send reminder emails


### PR DESCRIPTION
- Hooks into the expiration warning emails cron in PMPro core to send out a reminder email x amount of days before the payment will be charged
- `pmprosd_reminder_email_days` filter determines when the reminder must be sent
- `pmprosd_send_reminder_email` filter determines if a reminder email should be sent at all
- `pmprosd_reminder` user meta is added once sent to a user