### PR TITLE
Begin of work to support custom delay for existing members who checkout for their same level

### DIFF
--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -479,12 +479,19 @@ function pmprosd_getDelayForLevelID( $level_id ) {
 		// See if the user has an expiration date set.
 		if ( empty( $subscription_start_date ) ) {
 			$clevel = pmpro_getSpecificMembershipLevelForUser( $user_id, $level_id );
-			$subscription_start_date = $clevel->enddate;
+			if ( ! empty( $clevel->enddate ) ) {
+				$subscription_start_date = $clevel->enddate;
+			}
 		}
-		$subscription_delay = $subscription_start_date < current_time( 'timestamp' ) ? '' : $subscription_start_date;
-		$subscription_delay = date( 'Y-m-d H:i:s', (int) $subscription_delay );
+
+		// Convert the date to a valid delay value.
+		if ( ! empty( $subscription_start_date ) ) {
+			$subscription_delay = $subscription_start_date < current_time( 'timestamp' ) ? '' : $subscription_start_date;
+			$subscription_delay = date( 'Y-m-d H:i:s', (int) $subscription_delay );
+		} else {
+			$subscription_delay = '';
+		}
 	} else {
-		// Inherit level settings.
 		$subscription_delay = '';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When an existing member checks out for their same level, they currently are charged the full level cost and delay as defined for the level.  

This PR extends Subscription Delay options to allow custom settings for members who are buying their same level only. The default behavior will inherit the delay set for all users, regardless of if they are "renewing", so existing sites will not be impacted by this change.

New people using this can now optionally define custom delay rules for renewals, as these screenshots show:

![Screenshot 2025-01-28 at 10 20 10 AM](https://github.com/user-attachments/assets/14ee7a77-6b56-4c79-8929-956fc1eff84d)

![Screenshot 2025-01-28 at 10 20 15 AM](https://github.com/user-attachments/assets/2f1522f8-01b6-4f64-b1b6-612f82763d42)

You can now use this Add On in combination with the Proration Add On to: set initial payment to $0 (automatically, no changes needed) and maintain current renewal date.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* FEATURE: Now supporting custom delay rules for existing members that renew their same exact level.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
