### PR TITLE
Return empty array instead of false from pmpro_getDCSDs()

### DIFF
--- a/pmpro-subscription-delays.php
+++ b/pmpro-subscription-delays.php
@@ -456,7 +456,7 @@ function pmpro_getDCSDs( $code_id ) {
 	if ( ! empty( $all_delays ) && ! empty( $all_delays[ $code_id ] ) ) {
 		return $all_delays[ $code_id ];
 	} else {
-		return false;
+		return array();
 	}
 }
 


### PR DESCRIPTION
## Summary
- `pmpro_getDCSDs()` returned `false` when no delays were found, but callers use the return value as an array.
- This caused a PHP 8.1+ deprecation warning: "Automatic conversion of false to array is deprecated" in `pmprosd_pmpro_save_discount_code_level()`.
- Changed the fallback return value from `false` to `array()` to match the expected return type.

## Test plan
- [ ] Save a discount code with a subscription delay and verify it saves correctly.
- [ ] Save a discount code for a level that has no existing delays and confirm no PHP warnings.
- [ ] Verify `pmprosd_getDelay()` still works correctly for codes with and without delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)